### PR TITLE
Acceptiong resolver functions for `options.url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,21 @@ Now that you've set up eleventy-load-css, you can reference a CSS file from an H
 
 ## Options
 
-| Name                        | Type              | Default | Description                                                            |
-| --------------------------- | ----------------- | ------- | ---------------------------------------------------------------------- |
-| [**`url`**](#url)           | `Boolean`         | `true`  | Processes `url` dependencies                                           |
-| [**`import`**](#import)     | `Boolean`         | `true`  | Processes `@import` dependencies                                       |
-| [**`minimize`**](#minimize) | `Boolean\|Object` | `false` | Minimize using [CleanCSS](https://github.com/jakubpawlowicz/clean-css) |
+| Name                        | Type                | Default | Description                                                            |
+| --------------------------- | ------------------- | ------- | ---------------------------------------------------------------------- |
+| [**`url`**](#url)           | `Boolean\|Function` | `true`  | Processes `url` dependencies                                           |
+| [**`import`**](#import)     | `Boolean`           | `true`  | Processes `@import` dependencies                                       |
+| [**`minimize`**](#minimize) | `Boolean\|Object`   | `false` | Minimize using [CleanCSS](https://github.com/jakubpawlowicz/clean-css) |
 
 ### `url`
 
-Type: `Boolean` Default: `true`
+Type: `Boolean|Function` Default: `true`
 
 If `true`, processes `url` functions as eleventy-load dependencies.
+
+If `Function`, calls the provided function to resolve the path of the dependency first, with an object containing the following:
+- `resourcePath`: the path of the resource currently being processed
+- `source`: the path of the resource in the `url`
 
 ```scss
 // eleventy-load will process cat.jpg if `url` is true

--- a/index.js
+++ b/index.js
@@ -90,9 +90,14 @@ module.exports = async function (content, _options = {}) {
     });
   }
 
+  const _resolve = ({ resourcePath, source }) =>
+    path.join(path.dirname(resourcePath), source);
+  const resolve = typeof options.url === "function" ? options.url : _resolve;
+  
   // Await dependencies and call replace functions to modify CSS
   for (const { rule, replace, source } of dependencies) {
-    const resource = path.join(path.dirname(this.resourcePath), source);
+    const config = { resourcePath: this.resourcePath, source };
+    const resource = resolve(config) || _resolve(config);
     replace(rule, await this.addDependency(resource));
   }
 


### PR DESCRIPTION
This patch updates URL handling to accept a resolver function, to enable custom source resolution.